### PR TITLE
removed aio=native from opts on vm config

### DIFF
--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -255,7 +255,7 @@ func (c *VMConfig) vmArguments(version *Version) ([]string, error) {
 	args = append(args, "-m", strconv.FormatInt(c.Memory, 10))
 	args = append(args, "-smp", strconv.Itoa(c.Cpus))
 	args = append(args, "-device", "virtio-blk-pci,id=blk0,bootindex=0,drive=hd0")
-	args = append(args, "-drive", "file="+c.Image+",if=none,id=hd0,aio=native,cache="+c.vmDriveCache())
+	args = append(args, "-drive", "file="+c.Image+",if=none,id=hd0,cache="+c.vmDriveCache())
 	if version.Major >= 1 && version.Minor >= 3 {
 		args = append(args, "-device", "virtio-rng-pci")
 	}


### PR DESCRIPTION
@milt this was the configuration change I had to make in order to get capstan to cooperate with vbox. There's already an open issue about this [bug](https://github.com/cloudius-systems/capstan/issues/166). That guy seems to be running into problems further down the line, but for our purposes I figured just throwing a fix on a fork would be good enough for now.

Keep in mind until that issue's resolved in order to get this working on VirtualBox we need to install capstan the following way:

``` bash
brew install go
go get github.com/yetanalytics/capstan
```